### PR TITLE
add libclang on path for rust-rocksdb 0.23 build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -40,6 +40,11 @@ namada:
 
   RUN pipx ensurepath
   RUN pipx install speculos
+
+  # Needed for rust-rocksdb 0.23 build
+  RUN apt install -y llvm
+  RUN ln -s /usr/lib/llvm-14/lib/libclang-14.so.1 /usr/lib/llvm-14/lib/libclang-14.so
+  ENV LIBCLANG_PATH /usr/lib/llvm-14/lib
     
   RUN rustup toolchain install $toolchain-x86_64-unknown-linux-gnu --no-self-update --component clippy,rustfmt,rls,rust-analysis,rust-docs,rust-src,llvm-tools-preview
   RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
I tested this in https://github.com/anoma/namada/actions/runs/13395314580/job/37412746250?pr=4378 by temporarily installing it the same way in the job