### PR TITLE
Revert "add libclang on path for rust-rocksdb 0.23 build"

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -40,11 +40,6 @@ namada:
 
   RUN pipx ensurepath
   RUN pipx install speculos
-
-  # Needed for rust-rocksdb 0.23 build
-  RUN apt install -y llvm
-  RUN ln -s /usr/lib/llvm-14/lib/libclang-14.so.1 /usr/lib/llvm-14/lib/libclang-14.so
-  ENV LIBCLANG_PATH /usr/lib/llvm-14/lib
     
   RUN rustup toolchain install $toolchain-x86_64-unknown-linux-gnu --no-self-update --component clippy,rustfmt,rls,rust-analysis,rust-docs,rust-src,llvm-tools-preview
   RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
This reverts commit 27c0f0a606a3523ad1815d8500866badb82bfea9.

it's not needed with https://github.com/anoma/namada/pull/4444